### PR TITLE
Further Optimize the codebase

### DIFF
--- a/FlavorTrack/Core/Business List/BusinessCell.swift
+++ b/FlavorTrack/Core/Business List/BusinessCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class BusinessCell: UICollectionViewCell {
 	/// Reusable identifier of the cell
-	static let REUSE_ID = "BusinessCell"
+	static let reuseIdentifier = "BusinessCell"
 	
 	private let profileImageView: FTProfileImageView = .init(frame: .zero)
 	private let businessNameLabel: FTPrimaryTitleLabel = .init(textAlignment: .center, ofSize: 13)
@@ -20,12 +20,12 @@ final class BusinessCell: UICollectionViewCell {
 		configure()
 	}
 	
-	func set(with business: Business) -> Void {
+	func set(with business: Business) {
 		businessNameLabel.text = business.name
 		profileImageView.downloadImage(from: business.imageURL)
 	}
 	
-	private func configure() -> Void {
+	private func configure() {
 		addAllSubviews(profileImageView, businessNameLabel)
 		
 		profileImageView.constrainToUpperHalf(of: self, padding: edgePadding)

--- a/FlavorTrack/Core/Business List/BusinessListVC.swift
+++ b/FlavorTrack/Core/Business List/BusinessListVC.swift
@@ -11,8 +11,8 @@ final class BusinessListVC: UIViewController, LoadableScreen {
 	
 	internal enum CollectionSection { case main }
 	
-	var businessType: String!
-	var searchedLocation: String!
+    private var businessType: String!
+    private var searchedLocation: String!
 	private var businessList: [Business] = []
 	private var filteredBusinessList: [Business] = []
 	
@@ -49,25 +49,25 @@ final class BusinessListVC: UIViewController, LoadableScreen {
 
 // MARK: - UI/Data Configuration
 private extension BusinessListVC {
-	private func configCollectionView() -> Void {
+	private func configCollectionView() {
 		collectionView = .init(frame: view.bounds, collectionViewLayout: UIHelper.makeThreeColumnFlowLayout(in: view))
 		view.addSubview(collectionView)
 		collectionView.backgroundColor = .systemBackground
-		collectionView.register(BusinessCell.self, forCellWithReuseIdentifier: BusinessCell.REUSE_ID)
+		collectionView.register(BusinessCell.self, forCellWithReuseIdentifier: BusinessCell.reuseIdentifier)
 		
 		collectionView.delegate = self // for pagination
 	}
 	
-	private func configDataSource() -> Void {
+	private func configDataSource() {
 		dataSource = .init(collectionView: collectionView,
 						   cellProvider: { (collectionView, indexPath, business) -> UICollectionViewCell? in
-			let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BusinessCell.REUSE_ID, for: indexPath) as! BusinessCell
+			let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BusinessCell.reuseIdentifier, for: indexPath) as! BusinessCell
 			cell.set(with: business)
 			return cell
 		})
 	}
 	
-	private func configSearchBar() -> Void {
+	private func configSearchBar() {
 		let searchController: UISearchController = .init()
 		searchController.searchBar.placeholder = NSLocalizedString("Search a name", comment: "The placeholder of search bar in Business list controller")
 		searchController.searchResultsUpdater = self
@@ -75,7 +75,7 @@ private extension BusinessListVC {
 		navigationItem.searchController = searchController
 	}
 	
-	private func getBusinessList(for businessType: String, near location: String) -> Void {
+	private func getBusinessList(for businessType: String, near location: String) {
 		showLoadingOverlay()
 		
 		defer { dismissLoadingOverlay() }
@@ -90,7 +90,7 @@ private extension BusinessListVC {
 		}
 	}
 	
-	private func updateUI(with newBusinessList: [Business]) -> Void {
+	private func updateUI(with newBusinessList: [Business]) {
 		businessList.append(contentsOf: newBusinessList)
 		
 		if businessList.isEmpty {
@@ -104,7 +104,7 @@ private extension BusinessListVC {
 		}
 	}
 	
-	private func updateData(using businessList: [Business]) -> Void {
+	private func updateData(using businessList: [Business]) {
 		var snapshot: NSDiffableDataSourceSnapshot<CollectionSection, Business> = .init()
 		snapshot.appendSections([.main])
 		snapshot.appendItems(businessList)

--- a/FlavorTrack/Core/BusinessInfoVC/BusinessInfoVC.swift
+++ b/FlavorTrack/Core/BusinessInfoVC/BusinessInfoVC.swift
@@ -48,7 +48,7 @@ final class BusinessInfoVC: UIViewController, LoadableScreen {
 
 private extension BusinessInfoVC {
 	
-	private func configNavigationBarButtons() -> Void {
+	private func configNavigationBarButtons() {
 		let doneBarBtn: UIBarButtonItem = .init(barButtonSystemItem: .done, target: self, action: #selector(dismissVC))
 		doneBarBtn.isAccessibilityElement = true
 		doneBarBtn.accessibilityLabel = NSLocalizedString("Done and dismiss view", comment: "The accessibility label of the Done navigation bar button")
@@ -61,7 +61,7 @@ private extension BusinessInfoVC {
 		navigationItem.setLeftBarButtonItems([favBarBtn], animated: true)
 	}
 	
-	private func layoutUIElements() -> Void {
+	private func layoutUIElements() {
 		view.addAllSubviewsAndDisableAutoConstraints(scrollView)
 		scrollView.addAllSubviewsAndDisableAutoConstraints(contentView)
 		contentView.addAllSubviewsAndDisableAutoConstraints(headerView, detailView, mapHostingView)
@@ -89,7 +89,7 @@ private extension BusinessInfoVC {
 		])
 	}
 	
-	private func configUIElements(for business: Business) -> Void {
+	private func configUIElements(for business: Business) {
 		addChildController(BusinessInfoHeaderVC(
 			for: business, near: searchedLocation.capitalized(with: .current)),
 			to: headerView)
@@ -97,11 +97,9 @@ private extension BusinessInfoVC {
 		addChildController(BusinessInfoMapVC(for: business, delegate: self), to: mapHostingView)
 	}
 	
-	@objc
-	private func dismissVC() { dismiss(animated: true) }
+	@objc private func dismissVC() { dismiss(animated: true) }
 	
-	@objc
-	private func favoriteButtonClicked() -> Void {
+	@objc private func favoriteButtonClicked() {
 		showLoadingOverlay()
 		defer { dismissLoadingOverlay() }
 		

--- a/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoDetailVC.swift
+++ b/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoDetailVC.swift
@@ -38,7 +38,7 @@ final class BusinessInfoDetailVC: UIViewController {
 }
 
 private extension BusinessInfoDetailVC {
-	private func layoutUIElements() -> Void {
+	private func layoutUIElements() {
 		view.addAllSubviewsAndDisableAutoConstraints(locationIcon, locationLabel, phoneIcon,
 													 phoneLabel, tagIcon, tagLabel, linkIcon, linkLabel)
 		
@@ -87,7 +87,7 @@ private extension BusinessInfoDetailVC {
 		])
 	}
 	
-	private func configUIElements() -> Void {
+	private func configUIElements() {
 		// Location
 		locationIcon.image = SFSymbols.mapPin
 		locationIcon.tintColor = .secondaryLabel
@@ -119,7 +119,7 @@ private extension BusinessInfoDetailVC {
 		linkLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(yelpUrlTapped)))
 	}
 	
-	private func configAccessibilityForIcons() -> Void {
+	private func configAccessibilityForIcons() {
 		locationIcon.isAccessibilityElement = true
 		locationIcon.accessibilityLabel = NSLocalizedString("Location", comment: "")
 		locationIcon.accessibilityValue = "icon"
@@ -137,8 +137,7 @@ private extension BusinessInfoDetailVC {
 		linkIcon.accessibilityValue = "icon"
 	}
 	
-	@objc
-	private func yelpUrlTapped(_ sender: UITapGestureRecognizer) {
+	@objc private func yelpUrlTapped(_ sender: UITapGestureRecognizer) {
 		guard let url = URL(string: business.yelpUrl) else { return }
 		UIApplication.shared.open(url)
 	}

--- a/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoHeaderVC.swift
+++ b/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoHeaderVC.swift
@@ -44,10 +44,10 @@ final class BusinessInfoHeaderVC: UIViewController {
 
 // MARK: - UI Configuration
 private extension BusinessInfoHeaderVC {
-	private func layoutUIElements() -> Void {
-		view.addAllSubviewsAndDisableAutoConstraints(profileImageView, nameLabel, distanceIcon,
-													 distanceLabel, openStatusIcon, openStatusLabel,
-													 costIcon, costLabel, underlyingCostLabel, ratingIcon, ratingLabel)
+	private func layoutUIElements() {
+        view.addAllSubviewsAndDisableAutoConstraints(profileImageView, nameLabel, distanceIcon,
+                                                     distanceLabel, openStatusIcon, openStatusLabel,
+                                                     costIcon, costLabel, underlyingCostLabel, ratingIcon, ratingLabel)
 		
 		let imgAndTextPadding: CGFloat = 12.0
 		let infoPiecePadding: CGFloat = 10.0
@@ -109,7 +109,7 @@ private extension BusinessInfoHeaderVC {
 		])
 	}
 	
-	private func configUIElements() -> Void {
+	private func configUIElements() {
 		profileImageView.downloadImage(from: business.imageURL)
 		
 		nameLabel.text = business.name
@@ -137,7 +137,7 @@ private extension BusinessInfoHeaderVC {
 		ratingLabel.text = "\(business.rating)"
 	}
 	
-	private func configAccessibilityForIcons() -> Void {
+	private func configAccessibilityForIcons() {
 		distanceIcon.isAccessibilityElement = true
 		distanceIcon.accessibilityLabel = NSLocalizedString("Distance", comment: "The noun")
 		distanceIcon.accessibilityValue = "icon"

--- a/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoMapVC.swift
+++ b/FlavorTrack/Core/BusinessInfoVC/Components/BusinessInfoMapVC.swift
@@ -42,7 +42,7 @@ final class BusinessInfoMapVC: UIViewController {
 
 private extension BusinessInfoMapVC {
 	
-	private func layoutUI() -> Void {
+	private func layoutUI() {
 		view.addAllSubviewsAndDisableAutoConstraints(mapView, callToActionButton)
 		mapView.constrainToUpperHalf(of: view)
 		callToActionButton.constrainToLowerHalf(of: view)
@@ -54,7 +54,7 @@ private extension BusinessInfoMapVC {
 		])
 	}
 	
-	private func configMapView() -> Void {
+	private func configMapView() {
 		mapView.isUserInteractionEnabled = true
 		mapView.layer.cornerRadius = 8.0
 		mapView.layer.borderWidth = 1
@@ -63,7 +63,7 @@ private extension BusinessInfoMapVC {
 		mapView.clipsToBounds = true
 	}
 	
-	private func configMapRegionAndAnnotation() -> Void {
+	private func configMapRegionAndAnnotation() {
 		let annotation = BusinessMapAnnotation.generate(from: business)
 		let zoomLevel = 0.005
 		mapView.region = MKCoordinateRegion(center: annotation.coordinate,
@@ -71,12 +71,11 @@ private extension BusinessInfoMapVC {
 		mapView.addAnnotation(annotation)
 	}
 	
-	private func configActionButton() -> Void {
+	private func configActionButton() {
 		callToActionButton.addTarget(self, action: #selector(didTapActionButton), for: .touchUpInside)
 	}
 	
-	@objc
-	private func didTapActionButton() -> Void {
+	@objc private func didTapActionButton() {
 		delegate.didRequestMapNavigation(to: business)
 	}
 }

--- a/FlavorTrack/Core/Favorite List/FavoriteListCell.swift
+++ b/FlavorTrack/Core/Favorite List/FavoriteListCell.swift
@@ -10,7 +10,7 @@ import UIKit
 final class FavoriteListCell: UITableViewCell {
 
 	/// Reusable identifier of the cell
-	static let REUSE_ID = "FavoriteCell"
+	static let reuseIdentifier = "FavoriteListCell"
 	
 	private let profileImageView: FTProfileImageView = .init(frame: .zero)
 	private let nameLabel: FTPrimaryTitleLabel = .init(textAlignment: .left, ofSize: 17)
@@ -25,7 +25,7 @@ final class FavoriteListCell: UITableViewCell {
 		configAccessibilityForIcons()
 	}
 	
-	private func configure() -> Void {
+	private func configure() {
 		accessoryType = .detailButton
 		
 		addAllSubviewsAndDisableAutoConstraints(profileImageView, nameLabel, ratingIcon,
@@ -83,7 +83,7 @@ final class FavoriteListCell: UITableViewCell {
 		tagLabel.text = favorite.readableCategories
 	}
 	
-	private func configAccessibilityForIcons() -> Void {
+	private func configAccessibilityForIcons() {
 		ratingIcon.isAccessibilityElement = true
 		ratingIcon.accessibilityLabel = NSLocalizedString("Rating", comment: "The noun")
 		ratingIcon.accessibilityValue = "icon"

--- a/FlavorTrack/Core/Favorite List/FavoriteListVC.swift
+++ b/FlavorTrack/Core/Favorite List/FavoriteListVC.swift
@@ -26,7 +26,7 @@ final class FavoriteListVC: UIViewController {
     }
     
 
-	private func getFavoriteList() -> Void {
+	private func getFavoriteList() {
 		let result = PersistenceManager.retrieveFavoritesAndHandleError()
 		switch result {
 			case .success(let favorites):
@@ -41,14 +41,14 @@ final class FavoriteListVC: UIViewController {
 		}
 	}
 
-	private func configTableView() -> Void {
+	private func configTableView() {
 		tableView = .init(frame: view.bounds, style: .insetGrouped)
 		view.addSubview(tableView)
 		
 		tableView.delegate = self
 		tableView.dataSource = self
 		tableView.rowHeight = 72
-		tableView.register(FavoriteListCell.self, forCellReuseIdentifier: FavoriteListCell.REUSE_ID)
+		tableView.register(FavoriteListCell.self, forCellReuseIdentifier: FavoriteListCell.reuseIdentifier)
 	}
 }
 
@@ -58,7 +58,7 @@ extension FavoriteListVC: UITableViewDelegate, UITableViewDataSource {
 	}
 	
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteListCell.REUSE_ID,
+		let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteListCell.reuseIdentifier,
 												 for: indexPath) as! FavoriteListCell
 		cell.set(with: allFavorites[indexPath.row])
 		return cell

--- a/FlavorTrack/Core/Search/SearchVC.swift
+++ b/FlavorTrack/Core/Search/SearchVC.swift
@@ -40,7 +40,7 @@ final class SearchVC: UIViewController {
 
 // MARK: - UI Configuration
 private extension SearchVC {
-	private func configLogoImageView() -> Void {
+	private func configLogoImageView() {
 		logoImageView.image = AppImages.ftLogo
 		
 		logoImageView.constrainSizeToConstant(200.0)
@@ -51,7 +51,7 @@ private extension SearchVC {
 		])
 	}
 	
-	private func configTextFields() -> Void {
+	private func configTextFields() {
 		locationTextField.constrainToLeadingAndTrailingAnchors(of: view, padding: edgePadding)
 		businessTypeTextField.constrainToLeadingAndTrailingAnchors(of: view, padding: edgePadding)
 		
@@ -68,7 +68,7 @@ private extension SearchVC {
 		businessTypeTextField.delegate = self
 	}
 	
-	private func configActionButton() -> Void {
+	private func configActionButton() {
 		callToActionButton.constrainToLeadingAndTrailingAnchors(of: view, padding: edgePadding)
 		
 		// extra constraints
@@ -80,8 +80,7 @@ private extension SearchVC {
 		callToActionButton.addTarget(self, action: #selector(validateAndPushBusinessListVC), for: .touchUpInside)
 	}
 	
-	@objc
-	private func validateAndPushBusinessListVC() -> Void {
+	@objc private func validateAndPushBusinessListVC() {
 		guard isLocationEntered else {
 			presentAlert(title: "No Location?",
 						 message: "Please enter an address, road name, or zip code, etc.\nThen we can search 😊.")

--- a/FlavorTrack/Core/Views/FTAlert.swift
+++ b/FlavorTrack/Core/Views/FTAlert.swift
@@ -51,7 +51,7 @@ final class FTAlert: UIViewController {
 
 // MARK: - UI Configuration
 private extension FTAlert {
-	private func configContainerView() -> Void {
+	private func configContainerView() {
 		view.addSubview(containerView)
 		containerView.pinToCenter(of: view)
 		
@@ -61,7 +61,7 @@ private extension FTAlert {
 		])
 	}
 	
-	private func configTitleLabel() -> Void {
+	private func configTitleLabel() {
 		containerView.addSubview(titleLabel)
 		titleLabel.text = NSLocalizedString(titleString ?? "Something went wrong", comment: "The text of the alert title")
 		
@@ -69,7 +69,7 @@ private extension FTAlert {
 		NSLayoutConstraint.activate([titleLabel.heightAnchor.constraint(equalToConstant: 28)])
 	}
 	
-	private func configAlertButton() -> Void {
+	private func configAlertButton() {
 		containerView.addSubview(alertButton)
 		alertButton.setTitle(NSLocalizedString(buttonTitleString ?? "OK", comment: "The text of the alert button title"), for: .normal)
 		alertButton.addTarget(self, action: #selector(dismissAlert), for: .touchUpInside)
@@ -78,8 +78,7 @@ private extension FTAlert {
 		NSLayoutConstraint.activate([alertButton.heightAnchor.constraint(equalToConstant: 48)])
 	}
 	
-	@objc
-	private func dismissAlert() -> Void { dismiss(animated: true) }
+	@objc private func dismissAlert() -> Void { dismiss(animated: true) }
 	
 	/// Message would fill up the space between title and action button,
 	/// so please call it after you have already configured the other 2 views

--- a/FlavorTrack/Core/Views/FTAlertContainerView.swift
+++ b/FlavorTrack/Core/Views/FTAlertContainerView.swift
@@ -16,7 +16,7 @@ final class FTAlertContainerView: UIView {
 		configure()
 	}
 	
-	private func configure() -> Void {
+	private func configure() {
 		disableAutoConstraints()
 		backgroundColor = .secondarySystemBackground
 		layer.cornerRadius = 16

--- a/FlavorTrack/Core/Views/FTEmptyStateView.swift
+++ b/FlavorTrack/Core/Views/FTEmptyStateView.swift
@@ -23,7 +23,7 @@ final class GHEmptyStateView: UIView {
 		messageLabel.text = NSLocalizedString(message, comment: "The text of the empty state view")
 	}
 	
-	private func configure() -> Void {
+	private func configure() {
 		addSubview(logoImageView)
 		addSubview(messageLabel)
 		

--- a/FlavorTrack/Core/Views/FTProfileImageView.swift
+++ b/FlavorTrack/Core/Views/FTProfileImageView.swift
@@ -18,7 +18,7 @@ final class FTProfileImageView: UIImageView {
 		configure()
 	}
 	
-	private func configure() -> Void {
+	private func configure() {
 		disableAutoConstraints()
 
 		image = placeholderImage

--- a/FlavorTrack/Extensions/LoadableScreen.swift
+++ b/FlavorTrack/Extensions/LoadableScreen.swift
@@ -11,12 +11,12 @@ import UIKit
 /// For example, when downloading data over internet.
 protocol LoadableScreen: AnyObject {
 	var containerView: UIView! { get set }
-	func showLoadingOverlay() -> Void
-	func dismissLoadingOverlay() -> Void
+	func showLoadingOverlay()
+	func dismissLoadingOverlay()
 }
 
 extension LoadableScreen where Self: UIViewController {
-	func showLoadingOverlay() -> Void {
+	func showLoadingOverlay() {
 		containerView = .init(frame: view.bounds)
 		view.addSubview(containerView)
 		containerView.backgroundColor = .systemBackground
@@ -36,7 +36,7 @@ extension LoadableScreen where Self: UIViewController {
 		indicatorOverlay.startAnimating()
 	}
 	
-	func dismissLoadingOverlay() -> Void {
+	func dismissLoadingOverlay() {
 		DispatchQueue.main.async { [weak self] in
 			self?.containerView.removeFromSuperview()
 			self?.containerView = nil

--- a/FlavorTrack/Extensions/UIView.swift
+++ b/FlavorTrack/Extensions/UIView.swift
@@ -14,21 +14,21 @@ extension UIView {
 	/// After this call, you MUST set the constraints programmatically!
 	func disableAutoConstraints() -> Void { translatesAutoresizingMaskIntoConstraints = false }
 	
-	func addAllSubviews(_ subviews: UIView...) -> Void {
+	func addAllSubviews(_ subviews: UIView...) {
 		for subview in subviews {
 			addSubview(subview)
 		}
 	}
 	
 	/// After this call, you MUST set the constraints programmatically!
-	func addAllSubviewsAndDisableAutoConstraints(_ subviews: UIView...) -> Void {
+	func addAllSubviewsAndDisableAutoConstraints(_ subviews: UIView...) {
 		for subview in subviews {
 			addSubview(subview)
 			subview.disableAutoConstraints()
 		}
 	}
 	
-	func pinToEdges(of superview: UIView) -> Void {
+	func pinToEdges(of superview: UIView) {
 		NSLayoutConstraint.activate([
 			topAnchor.constraint(equalTo: superview.topAnchor),
 			leadingAnchor.constraint(equalTo: superview.leadingAnchor),
@@ -38,7 +38,7 @@ extension UIView {
 	}
 	
 	/// Centers the view horizontally and vertically 
-	func pinToCenter(of superview: UIView) -> Void {
+	func pinToCenter(of superview: UIView) {
 		NSLayoutConstraint.activate([
 			centerXAnchor.constraint(equalTo: superview.centerXAnchor),
 			centerYAnchor.constraint(equalTo: superview.centerYAnchor)
@@ -46,7 +46,7 @@ extension UIView {
 	}
 	
 	/// Constrains the view to its superview's top, leading, and trailing anchors with a padding (defaults to 0)
-	func constrainToUpperHalf(of superview: UIView, padding: CGFloat = 0.0) -> Void {
+	func constrainToUpperHalf(of superview: UIView, padding: CGFloat = 0.0) {
 		NSLayoutConstraint.activate([
 			topAnchor.constraint(equalTo: superview.topAnchor, constant: padding),
 			leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: padding),
@@ -55,7 +55,7 @@ extension UIView {
 	}
 	
 	/// Constrains the view to its superview's bottom, leading, and trailing anchors with a padding (defaults to 0)
-	func constrainToLowerHalf(of superview: UIView, padding: CGFloat = 0.0) -> Void {
+	func constrainToLowerHalf(of superview: UIView, padding: CGFloat = 0.0) {
 		NSLayoutConstraint.activate([
 			bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -(padding)),
 			leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: padding),
@@ -64,7 +64,7 @@ extension UIView {
 	}
 	
 	/// Constrains the view to its superview's leading and trailing anchors with a padding (defaults to 0)
-	func constrainToLeadingAndTrailingAnchors(of superview: UIView, padding: CGFloat = 0.0) -> Void {
+	func constrainToLeadingAndTrailingAnchors(of superview: UIView, padding: CGFloat = 0.0) {
 		NSLayoutConstraint.activate([
 			leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: padding),
 			trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -(padding))
@@ -72,7 +72,7 @@ extension UIView {
 	}
 	
 	/// Constrains the height and width anchors with the same value, aka constrains it within a square
-	func constrainSizeToConstant(_ constant: CGFloat) -> Void {
+	func constrainSizeToConstant(_ constant: CGFloat) {
 		NSLayoutConstraint.activate([
 			heightAnchor.constraint(equalToConstant: constant),
 			widthAnchor.constraint(equalToConstant: constant)

--- a/FlavorTrack/Extensions/UIViewController.swift
+++ b/FlavorTrack/Extensions/UIViewController.swift
@@ -10,8 +10,7 @@ import UIKit
 // MARK: - Keyboard
 extension UIViewController {
 	
-	@objc
-	func keyboardWillShow(sender notification: NSNotification) {
+	@objc func keyboardWillShow(sender notification: NSNotification) {
 		guard let userInfo = notification.userInfo,
 			  let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
 			  let currentTextField = UIResponder.currentFirst() as? UITextField else { return }
@@ -29,8 +28,7 @@ extension UIViewController {
 		}
 	}
 	
-	@objc
-	func keyboardWillHide(sender notification: NSNotification) {
+	@objc func keyboardWillHide(sender notification: NSNotification) {
 		view.frame.origin.y = 0
 	}
 }
@@ -39,7 +37,7 @@ extension UIViewController {
 	/// Presents custom alert on main thread
 	func presentAlert(title: String = "Something bad happened",
 					  message: String,
-					  buttonTitle: String = "OK") -> Void {
+					  buttonTitle: String = "OK") {
 		
 		DispatchQueue.main.async { [weak self] in
 			let alert: FTAlert = .init(title: title, message: message, btnTitle: buttonTitle)
@@ -49,18 +47,18 @@ extension UIViewController {
 		}
 	}
 	
-	func presentDefaultAlert() -> Void {
+	func presentDefaultAlert() {
 		presentAlert(message: BusinessDataService.NetworkError.unableToComplete.rawValue)
 	}
 	
-	func showEmptyStateView(saying message: String, in view: UIView) -> Void {
+	func showEmptyStateView(saying message: String, in view: UIView) {
 		let emptyStateView: GHEmptyStateView = .init(message: message)
 		emptyStateView.frame = view.bounds
 		view.addSubview(emptyStateView)
 	}
 	
 	/// Place a child view controller into a custom view that this view controller manages
-	func addChildController(_ childController: UIViewController, to containerView: UIView) -> Void {
+	func addChildController(_ childController: UIViewController, to containerView: UIView) {
 		addChild(childController)
 		containerView.addSubview(childController.view)
 		childController.view.frame = containerView.bounds


### PR DESCRIPTION
* Change the name of type property called REUSE_ID to reuseIdentifier as all capital letter instance name is generally discouraged.
* Remove return type, -> Void, from functions as it is unnecessary.
* Change code to ensure '@objc' keyword is in the same line as function signature.